### PR TITLE
Allow actions on parent when using ui automator

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorExecute.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorExecute.java
@@ -8,6 +8,7 @@ import android.support.test.uiautomator.UiObjectNotFoundException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,25 +22,39 @@ public class UiautomatorExecute implements Action {
         UiDevice mDevice = InstrumentationBackend.getUiDevice();
         String text = null;
         try {
-            verifyStrategy(args[0]);
-            verifyAction(args[3]);
-            Method methodName = By.class.getMethod(args[0], String.class);
-            BySelector selector = (BySelector) methodName.invoke(By.class, args[1]);
+            String strategy = args[0];
+            String locator = args[1];
+            String index = args[2];
+            String action = args[3];
 
-            Method methodOperation = UiObject2.class.getMethod(args[3]);
+            verifyStrategy(strategy);
+            verifyAction(action);
 
-            List<UiObject2> objects = mDevice.findObjects(selector);
-            if (objects.isEmpty()) {
-                String errorMessage = String.format("Found no elements for locator: %s by strategy: %s", args[1], args[0]);
+            Method strategyMethod = By.class.getMethod(strategy, String.class);
+            BySelector selector = (BySelector) strategyMethod.invoke(By.class, locator);
+
+            List<UiObject2> matchingObjects = mDevice.findObjects(selector);
+            if (matchingObjects.isEmpty()) {
+                String errorMessage = String.format("Found no elements for locator: %s by strategy: %s", locator, strategy);
                 throw new UiObjectNotFoundException(errorMessage);
             }
-            UiObject2 object = objects.get(Integer.parseInt(args[2]));
+            UiObject2 targetObject = matchingObjects.get(Integer.parseInt(index));
 
-            Object res = methodOperation.invoke(object);
-            if (res != null) {
-                text = res.toString();
+            Object result;
+            if (isActionOnParent(action)) {
+                Method getParentMethod = UiObject2.class.getMethod("getParent");
+                UiObject2 targetObjectParent = (UiObject2) getParentMethod.invoke(targetObject);
+
+                Method actionMethod = UiObject2.class.getMethod(extractAction(action));
+                result = actionMethod.invoke(targetObjectParent);
+            } else {
+                Method actionMethod = UiObject2.class.getMethod(action);
+                result = actionMethod.invoke(targetObject);
             }
 
+            if (result != null) {
+                text = result.toString();
+            }
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
             return new Result(false, e.getMessage());
@@ -69,11 +84,23 @@ public class UiautomatorExecute implements Action {
 
     private static void verifyAction(String action) {
         try {
-            Actions.valueOf(action);
+            Actions.valueOf(extractAction(action));
         } catch (IllegalArgumentException e) {
-            List<Actions> availableActions = Arrays.asList(Actions.values());
+            List<String> availableActions = new ArrayList<>();
+            for (Actions a : Actions.values()) {
+                availableActions.add(a.toString());
+                availableActions.add("parent:" + a);
+            }
             String errorMessage = String.format("Unsupported action: %s. The list of available actions is %s", action, availableActions);
             throw new IllegalArgumentException(errorMessage);
         }
+    }
+
+    private static boolean isActionOnParent(String action) {
+        return action.contains("parent:");
+    }
+
+    private static String extractAction(String actionOnParent) {
+        return actionOnParent.replace("parent:", "");
     }
 }


### PR DESCRIPTION
Background:

While introducing Jetpack compose in our android project, we noticed that calabash is not able to identify compose ui components while ui automator is. Even if ui automator is able to "see" elements in the ui, it is very difficult to interact with them because there are no identifiers. We have to use text and content description to identify components and interact with them.

Some compose components are identified by ui automator as multiple nodes and this prevents us from properly interacting with them. For example, one checkbox is represented by a parent node that is checkable and two child nodes: one containing the text and one containing the checkbox icon (both of them not checkable). As we can only use text to identify a component, in this case we receive the child node containing the text, that is not checkable. In order to access the "checked" status we need to get the parent node of the identified node and to be able to execute ui automator actions on it.

Solution:
Allow calabash to execute ui automator actions on the parent of a located node.